### PR TITLE
api fix : streamToBlobURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function validateFile (file) {
 
 function handleError (file, el, cb) {
   var elem = document.createElement('iframe')
-  streamToBlobURL(file.createReadStream(), 'text/plain', function (err, url) {
+  streamToBlobURL(file.createReadStream(), function (err, url) {
     if (err) return cb(err)
     elem.src = url
     elem.sandbox = 'allow-forms allow-scripts'

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "csv-parser": "^1.9.3",
     "render-media": "^2.0.2",
-    "stream-to-blob-url": "^2.0.0"
+    "stream-to-blob-url": "^2.1.0"
   }
 }


### PR DESCRIPTION
hi @karissa 

`stream-to-blob-url` is now using `stream-to-blob` instead of `once`, and there is a little change in it's structure. 

**OLD :**
- `toBlobURL(fs.createReadStream('file.txt'), 'file.txt', function (err, url) {`
- `toBlobURL(fs.createReadStream('file.txt'), 'text/plain', function (err, url) {`

**CURRENT :**
- `toBlobURL(fs.createReadStream('file.txt'), function (err, url) {`
